### PR TITLE
Add Pint and PHPStan static analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,53 @@
+name: static-analysis
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    name: PHPStan
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run PHPStan
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G
+
+  pint:
+    runs-on: ubuntu-latest
+
+    name: Pint
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,3 +55,18 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit
+
+  tests-required:
+    name: Tests Required
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs:
+      - tests
+
+    steps:
+      - name: Verify test matrix completed successfully
+        run: |
+          if [ "${{ needs.tests.result }}" != "success" ]; then
+            echo "Test matrix result: ${{ needs.tests.result }}"
+            exit 1
+          fi

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,0 @@
-preset: laravel
-
-disabled:
-  - laravel_phpdoc_alignment
-  - laravel_phpdoc_separation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@
 ### Added
 - Added support for Laravel 13.
 - Added support for PHP 8.5.
+- Added Pint and PHPStan static analysis tooling and CI checks.
 
 ### Changed
 - Increase minimum PHP version to 8.2.
 - Increase minimum Laravel version to 12.0.
 - Updated dependabot configuration.
+- Tightened facade and test/provider annotations for static analysis.
 
 ### Removed
+- Removed StyleCI configuration.
 - Removed support for PHP 8.1.
 - Removed support for Laravel 10.
 - Removed support for Laravel 11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for Laravel 13.
 - Added support for PHP 8.5.
 - Added Pint and PHPStan static analysis tooling and CI checks.
+- Added a required aggregate GitHub Actions job for the test matrix.
 
 ### Changed
 - Increase minimum PHP version to 8.2.

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
     "spatie/packagist-api": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.5|^11.0",
-    "orchestra/testbench": "10.*|^11.0"
+    "larastan/larastan": "^3.9",
+    "laravel/pint": "^1.29",
+    "orchestra/testbench": "10.*|^11.0",
+    "phpunit/phpunit": "^10.5|^11.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,10 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - vendor/nesbot/carbon/extension.neon
+
+parameters:
+    paths:
+        - src/
+        - tests/
+
+    level: 6

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,37 @@
+{
+  "preset": "laravel",
+  "rules": {
+    "assign_null_coalescing_to_coalesce_equal": true,
+    "blank_line_before_statement": true,
+    "class_attributes_separation": {
+      "elements": {
+        "const": "none",
+        "method": "one",
+        "property": "one",
+        "trait_import": "none"
+      }
+    },
+    "fully_qualified_strict_types": {
+      "import_symbols": true,
+      "leading_backslash_in_global_namespace": false,
+      "phpdoc_tags": [
+        "method",
+        "param",
+        "return",
+        "throws",
+        "type",
+        "var"
+      ]
+    },
+    "global_namespace_import": true,
+    "phpdoc_separation": false,
+    "phpdoc_summary": true,
+    "phpdoc_align": {
+      "align": "left",
+      "spacing": {
+        "param": 1
+      }
+    },
+    "no_superfluous_phpdoc_tags": false
+  }
+}

--- a/src/Facades/Packagist.php
+++ b/src/Facades/Packagist.php
@@ -8,16 +8,16 @@ use Spatie\Packagist\PackagistClient;
 /**
  * Class Packagist.
  *
- * @method static array|null getPackagesNames(?string $type = null, ?string $vendor = null)
- * @method static array|null getPackagesNamesByType(string $type)
- * @method static array|null getPackagesNamesByVendor(string $vendor)
- * @method static array|null searchPackages($name = null, array $filters = [], ?int $page = 1, int $perPage = 15)
- * @method static array|null searchPackagesByName(string $name, ?int $page = 1, int $perPage = 15):
- * @method static array|null searchPackagesByTags(string $tags, ?string $name = null, ?int $page = 1, int $perPage = 15)
- * @method static array|null searchPackagesByType(string $type, ?string $name = null, ?int $page = 1, int $perPage = 15)
- * @method static array|null getPackage(string $vendor, ?string $package = null)
- * @method static array|null getPackageMetadata(string $vendor, ?string $package = null)
- * @method static array|null getStatistics()
+ * @method static array<int|string, mixed>|null getPackagesNames(?string $type = null, ?string $vendor = null)
+ * @method static array<int|string, mixed>|null getPackagesNamesByType(string $type)
+ * @method static array<int|string, mixed>|null getPackagesNamesByVendor(string $vendor)
+ * @method static array<int|string, mixed>|null searchPackages($name = null, array<int|string, mixed> $filters = [], ?int $page = 1, int $perPage = 15)
+ * @method static array<int|string, mixed>|null searchPackagesByName(string $name, ?int $page = 1, int $perPage = 15)
+ * @method static array<int|string, mixed>|null searchPackagesByTags(string $tags, ?string $name = null, ?int $page = 1, int $perPage = 15)
+ * @method static array<int|string, mixed>|null searchPackagesByType(string $type, ?string $name = null, ?int $page = 1, int $perPage = 15)
+ * @method static array<int|string, mixed>|null getPackage(string $vendor, ?string $package = null)
+ * @method static array<int|string, mixed>|null getPackageMetadata(string $vendor, ?string $package = null)
+ * @method static array<int|string, mixed>|null getStatistics()
  * @see PackagistClient
  */
 class Packagist extends Facade

--- a/src/PackagistServiceProvider.php
+++ b/src/PackagistServiceProvider.php
@@ -23,7 +23,7 @@ class PackagistServiceProvider extends ServiceProvider implements DeferrableProv
         $this->app->bind(PackagistClient::class, function (Application $app) {
             $urlGenerator = $app->make(PackagistUrlGenerator::class);
 
-            return new PackagistClient(new Client(), $urlGenerator);
+            return new PackagistClient(new Client, $urlGenerator);
         });
 
         $this->app->bind(PackagistUrlGenerator::class, function (Application $app) {
@@ -40,7 +40,7 @@ class PackagistServiceProvider extends ServiceProvider implements DeferrableProv
     /**
      * Get the services provided by the provider.
      *
-     * @return array
+     * @return array<int, class-string>
      */
     public function provides()
     {

--- a/tests/LaravelTestCase.php
+++ b/tests/LaravelTestCase.php
@@ -13,7 +13,7 @@ class LaravelTestCase extends TestCase
      *
      * @param Application $app
      *
-     * @return array
+     * @return array<int, class-string>
      */
     protected function getPackageProviders($app)
     {


### PR DESCRIPTION
## Summary
- add Laravel Pint and Larastan as development dependencies
- add Pint and PHPStan configuration plus a GitHub Actions workflow for static analysis
- tighten facade and provider/test annotations so PHPStan level 6 passes on src and tests

## Why
This adds automated formatting and static analysis checks to the package so style and type issues are caught in CI before merge.